### PR TITLE
Adding a shouldInvalidateAfter method

### DIFF
--- a/__mocks__/authenticatorMocks.ts
+++ b/__mocks__/authenticatorMocks.ts
@@ -170,3 +170,63 @@ export class mockAuthenticatorToAutoLogin extends Authenticator {
     return false
   }
 }
+
+export class mockAuthenticatorToInvalidate extends Authenticator {
+  constructor(chains: Chain[]) {
+    super(chains)
+  }
+
+  public init(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  public reset(): void {}
+
+  public isErrored(): boolean {
+    return false
+  }
+
+  public getOnboardingLink(): string {
+    return ''
+  }
+
+  public getError(): UALError | null {
+    return null
+  }
+
+  public isLoading(): boolean {
+    return true
+  }
+
+  public getStyle(): ButtonStyle {
+    throw new Error('method not implemented')
+  }
+
+  public shouldRender(): boolean {
+    return true
+  }
+
+  public shouldAutoLogin(): boolean {
+    return false
+  }
+
+  public shouldInvalidateAfter(): number {
+    return 0
+  }
+
+  public shouldRequestAccountName(): Promise<boolean> {
+    throw new Error('method not implemented')
+  }
+
+  public login(accountName?: string): Promise<User[]> {
+    throw new Error(`method not implemented for ${accountName}`)
+  }
+
+  public logout(): Promise<void> {
+    throw new Error('method not implemented')
+  }
+
+  public requiresGetKeyConfirmation(): boolean {
+    return false
+  }
+}

--- a/__mocks__/authenticatorMocks.ts
+++ b/__mocks__/authenticatorMocks.ts
@@ -1,9 +1,10 @@
+// tslint:disable:max-classes-per-file
 import { Authenticator } from '../src/Authenticator'
-import { UALError } from '../src/UALError'
 import { ButtonStyle, Chain } from '../src/interfaces'
+import { UALError } from '../src/UALError'
 import { User } from '../src/User'
 
-export class mockAuthenticatorToRender extends Authenticator {
+class MockAuthenticator extends Authenticator {
   constructor(chains: Chain[]) {
     super(chains)
   }
@@ -11,45 +12,45 @@ export class mockAuthenticatorToRender extends Authenticator {
   public init(): Promise<void> {
     return Promise.resolve()
   }
-  
+
   public reset(): void {}
-  
+
   public isErrored(): boolean {
     return false
   }
-  
+
   public getOnboardingLink(): string {
     return ''
   }
-  
+
   public getError(): UALError | null {
     return null
   }
-  
+
   public isLoading(): boolean {
     return true
   }
-  
+
   public getStyle(): ButtonStyle {
-   throw new Error('method not implemented')
+    throw new Error('method not implemented')
   }
-  
+
   public shouldRender(): boolean {
     return true
   }
-  
+
   public shouldAutoLogin(): boolean {
     return false
   }
-  
+
   public shouldRequestAccountName(): Promise<boolean> {
     throw new Error('method not implemented')
   }
-  
+
   public login(accountName?: string): Promise<User[]> {
     throw new Error(`method not implemented for ${accountName}`)
   }
-  
+
   public logout(): Promise<void> {
     throw new Error('method not implemented')
   }
@@ -59,174 +60,42 @@ export class mockAuthenticatorToRender extends Authenticator {
   }
 }
 
-export class mockAuthenticatorToNotRender extends Authenticator {
+export class MockAuthenticatorToRender extends MockAuthenticator {
   constructor(chains: Chain[]) {
     super(chains)
   }
 
-  public init(): Promise<void> {
-    return Promise.resolve()
-  }
-  
-  public reset(): void {}
-  
-  public isErrored(): boolean {
-    return false
-  }
-  
-  public getOnboardingLink(): string {
-    return ''
-  }
-  
-  public getError(): UALError | null {
-    return null
-  }
-  
-  public isLoading(): boolean {
+  public shouldRender(): boolean {
     return true
   }
-  
-  public getStyle(): ButtonStyle {
-   throw new Error('method not implemented')
-  }
-  
-  public shouldRender(): boolean {
-    return false
-  }
-  
-  public shouldAutoLogin(): boolean {
-    return false
-  }
-  
-  public shouldRequestAccountName(): Promise<boolean> {
-    throw new Error('method not implemented')
-  }
-  
-  public login(accountName?: string): Promise<User[]> {
-    throw new Error(`method not implemented for ${accountName}`)
-  }
-  
-  public logout(): Promise<void> {
-    throw new Error('method not implemented')
+}
+
+export class MockAuthenticatorToNotRender extends MockAuthenticator {
+  constructor(chains: Chain[]) {
+    super(chains)
   }
 
-  public requiresGetKeyConfirmation(): boolean {
+  public shouldRender(): boolean {
     return false
   }
 }
 
-export class mockAuthenticatorToAutoLogin extends Authenticator {
+export class MockAuthenticatorToAutoLogin extends MockAuthenticator {
   constructor(chains: Chain[]) {
     super(chains)
   }
 
-  public init(): Promise<void> {
-    return Promise.resolve()
-  }
-  
-  public reset(): void {}
-  
-  public isErrored(): boolean {
-    return false
-  }
-  
-  public getOnboardingLink(): string {
-    return ''
-  }
-  
-  public getError(): UALError | null {
-    return null
-  }
-  
-  public isLoading(): boolean {
-    return true
-  }
-  
-  public getStyle(): ButtonStyle {
-   throw new Error('method not implemented')
-  }
-  
-  public shouldRender(): boolean {
-    return true
-  }
-  
   public shouldAutoLogin(): boolean {
     return true
-  }
-  
-  public shouldRequestAccountName(): Promise<boolean> {
-    throw new Error('method not implemented')
-  }
-  
-  public login(accountName?: string): Promise<User[]> {
-    throw new Error(`method not implemented for ${accountName}`)
-  }
-  
-  public logout(): Promise<void> {
-    throw new Error('method not implemented')
-  }
-
-  public requiresGetKeyConfirmation(): boolean {
-    return false
   }
 }
 
-export class mockAuthenticatorToInvalidate extends Authenticator {
+export class MockAuthenticatorToInvalidate extends MockAuthenticator {
   constructor(chains: Chain[]) {
     super(chains)
-  }
-
-  public init(): Promise<void> {
-    return Promise.resolve()
-  }
-
-  public reset(): void {}
-
-  public isErrored(): boolean {
-    return false
-  }
-
-  public getOnboardingLink(): string {
-    return ''
-  }
-
-  public getError(): UALError | null {
-    return null
-  }
-
-  public isLoading(): boolean {
-    return true
-  }
-
-  public getStyle(): ButtonStyle {
-    throw new Error('method not implemented')
-  }
-
-  public shouldRender(): boolean {
-    return true
-  }
-
-  public shouldAutoLogin(): boolean {
-    return false
   }
 
   public shouldInvalidateAfter(): number {
     return 0
-  }
-
-  public shouldRequestAccountName(): Promise<boolean> {
-    throw new Error('method not implemented')
-  }
-
-  public login(accountName?: string): Promise<User[]> {
-    throw new Error(`method not implemented for ${accountName}`)
-  }
-
-  public logout(): Promise<void> {
-    throw new Error('method not implemented')
-  }
-
-  public requiresGetKeyConfirmation(): boolean {
-    return false
   }
 }

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -6,6 +6,12 @@ import { User } from './User'
  * Represents Button that is rendered for, and interfaces with, a specific Authenticator app.
  */
 export abstract class Authenticator {
+
+  /**
+   * Default value for shouldInvalidateAfter(), 1 week in seconds
+   */
+  private defaultInvalidateAfter = 604800
+
   /**
    * @param chains     This represents each of the chains that the dapp provides support for.
    *
@@ -75,7 +81,7 @@ export abstract class Authenticator {
    * should not be relied on for security.
    */
   public shouldInvalidateAfter(): number {
-    return 604800
+    return this.defaultInvalidateAfter
   }
 
   /**

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -69,6 +69,16 @@ export abstract class Authenticator {
   public abstract shouldRequestAccountName(): Promise<boolean>
 
   /**
+   * Returns the amount of seconds after the authentication will be invalid for logging in on new
+   * browser sessions.  Setting this value to zero will cause users to re-attempt authentication on
+   * every new browser session.  Please note that the invalidate time will be saved client-side and
+   * should not be relied on for security.
+   */
+  public shouldInvalidateAfter(): number {
+    return 604800
+  }
+
+  /**
    * Login using the Authenticator App. This can return one or more users depending on multiple chain support.
    *
    * @param accountName  The account name of the user for Authenticators that do not store accounts (optional)

--- a/src/UAL.test.ts
+++ b/src/UAL.test.ts
@@ -2,7 +2,8 @@ import { Authenticator } from './Authenticator'
 import {
   mockAuthenticatorToRender,
   mockAuthenticatorToNotRender,
-  mockAuthenticatorToAutoLogin
+  mockAuthenticatorToAutoLogin,
+  mockAuthenticatorToInvalidate
 } from '../__mocks__/authenticatorMocks'
 import { AuthenticatorResponse, Chain } from './interfaces'
 import { UAL } from './UAL'
@@ -23,15 +24,18 @@ describe('UAL', () => {
   let renderMe: Authenticator
   let dontRenderMe: Authenticator
   let autoLoginMe: Authenticator
+  let invalidateMe: Authenticator
 
   beforeAll(() => {
     renderMe = new mockAuthenticatorToRender([mockChain])
     dontRenderMe = new mockAuthenticatorToNotRender([mockChain])
     autoLoginMe = new mockAuthenticatorToAutoLogin([mockChain])
+    invalidateMe = new mockAuthenticatorToInvalidate([mockChain])
     authenticators = [
       renderMe,
       dontRenderMe,
-      autoLoginMe
+      autoLoginMe,
+      invalidateMe
     ]
     ual = new UAL([mockChain], 'My App', authenticators)
   })
@@ -42,6 +46,7 @@ describe('UAL', () => {
       renderMe.init = jest.fn()
       dontRenderMe.init = jest.fn()
       autoLoginMe.init = jest.fn()
+      invalidateMe.init = jest.fn()
     })
     beforeEach(() => {
       response = ual.getAuthenticators()
@@ -60,6 +65,7 @@ describe('UAL', () => {
     it('that filters in authenticators that should be rendered', () => {
       expect(response.availableAuthenticators.indexOf(renderMe)).not.toEqual(-1)
       expect(response.availableAuthenticators.indexOf(autoLoginMe)).not.toEqual(-1)
+      expect(response.availableAuthenticators.indexOf(invalidateMe)).not.toEqual(-1)
     })
 
     it('that filters out authenticators that cannot be rendered', () => {
@@ -69,6 +75,7 @@ describe('UAL', () => {
     it('that calls init on all available authenticators', () => {
       expect(renderMe.init).toHaveBeenCalled()
       expect(autoLoginMe.init).toHaveBeenCalled()
+      expect(invalidateMe.init).toHaveBeenCalled()
     })
 
     it('that does not call init on unavailable authenticators', () => {
@@ -77,6 +84,14 @@ describe('UAL', () => {
 
     it('that returns an auto-login authenticator if it is the only one available', () => {
       expect(response.autoLoginAuthenticator).toEqual(null)
+    })
+
+    it('that returns an invalidate after authenticator with correct setting', () => {
+      expect(invalidateMe.shouldInvalidateAfter()).toEqual(0)
+    })
+
+    it('that returns an authenticator without shouldInvalidateAfter to have default setting', () => {
+      expect(autoLoginMe.shouldInvalidateAfter()).toEqual(604800)
     })
 
     it('that does not return an auto-login authenticator if other authenticators are available', () => {

--- a/src/UAL.test.ts
+++ b/src/UAL.test.ts
@@ -1,10 +1,10 @@
-import { Authenticator } from './Authenticator'
 import {
-  mockAuthenticatorToRender,
-  mockAuthenticatorToNotRender,
-  mockAuthenticatorToAutoLogin,
-  mockAuthenticatorToInvalidate
+  MockAuthenticatorToAutoLogin,
+  MockAuthenticatorToInvalidate,
+  MockAuthenticatorToNotRender,
+  MockAuthenticatorToRender
 } from '../__mocks__/authenticatorMocks'
+import { Authenticator } from './Authenticator'
 import { AuthenticatorResponse, Chain } from './interfaces'
 import { UAL } from './UAL'
 
@@ -27,10 +27,10 @@ describe('UAL', () => {
   let invalidateMe: Authenticator
 
   beforeAll(() => {
-    renderMe = new mockAuthenticatorToRender([mockChain])
-    dontRenderMe = new mockAuthenticatorToNotRender([mockChain])
-    autoLoginMe = new mockAuthenticatorToAutoLogin([mockChain])
-    invalidateMe = new mockAuthenticatorToInvalidate([mockChain])
+    renderMe = new MockAuthenticatorToRender([mockChain])
+    dontRenderMe = new MockAuthenticatorToNotRender([mockChain])
+    autoLoginMe = new MockAuthenticatorToAutoLogin([mockChain])
+    invalidateMe = new MockAuthenticatorToInvalidate([mockChain])
     authenticators = [
       renderMe,
       dontRenderMe,


### PR DESCRIPTION
## Change Description
While investigating #48, it was found that ual-reactjs-renderer is saving the authentication session information in local storage for indefinite time.  This is intended to emulate other sites authentication process with cookies by re-using that information and automatically re-logging the user back in.  However, some authenticators might want the ability to invalidate said session information after a certain time.  Additionally, authenticators that never want to re-use authentication session information can set this to zero.

## API Changes
- [x] API Changes
Adding an optional additional Authenticator method, defaulted to 1 week of invalidate time

## Documentation Additions
- [ ] Documentation Additions
